### PR TITLE
Fix: convert durations to datetime.timedelta objects

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,9 +42,17 @@ Also, methods to extract certain HDF group attributes as dictionaries:
 ```python
 >>> from rashdf import RasPlanHdf
 >>> with RasPlanHdf("path/to/rasmodel/Muncie.p04.hdf") as plan_hdf:
->>>     results_unsteady_summary = plan_hdf.get_results_unsteady_summary()
+>>> results_unsteady_summary = plan_hdf.get_results_unsteady_summary()
 >>> results_unsteady_summary
-{'Computation Time DSS': '00:00:00', 'Computation Time Total': '00:00:23', 'Maximum WSEL Error': 0.0099277812987566, 'Maximum number of cores': 6, 'Run Time Window': [datetime.datetime(2024, 3, 27, 9, 31, 52), datetime.datetime(2024, 3, 27, 9, 32, 15)], 'Solution': 'Unsteady Finished Successfully', 'Time Solution Went Unstable': None, 'Time Stamp Solution Went Unstable': 'Not Applicable'}
+{'Computation Time DSS': datetime.timedelta(0),
+'Computation Time Total': datetime.timedelta(seconds=23),
+'Maximum WSEL Error': 0.0099277812987566,
+'Maximum number of cores': 6,
+'Run Time Window': [datetime.datetime(2024, 3, 27, 9, 31, 52),
+datetime.datetime(2024, 3, 27, 9, 32, 15)],
+'Solution': 'Unsteady Finished Successfully',
+'Time Solution Went Unstable': None,
+'Time Stamp Solution Went Unstable': 'Not Applicable'}
 ```
 
 ## Documentation

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ classifiers = [
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
 ]
-version = "0.1.0"
+version = "0.1.1"
 dependencies = ["h5py", "geopandas"]
 
 [project.optional-dependencies]
@@ -24,3 +24,11 @@ repository = "https://github.com/fema-ffrd/rashdf"
 [tool.pytest.ini_options]
 pythonpath = "src"
 testpaths = "tests"
+
+# TODO: linting for docstrings.
+# https://github.com/fema-ffrd/rashdf/issues/15
+# [tool.ruff.lint]
+# select = ["D"]
+
+# [tool.ruff.lint.pydocstyle]
+# convention = "numpy"

--- a/src/rashdf/utils.py
+++ b/src/rashdf/utils.py
@@ -93,8 +93,8 @@ def convert_ras_hdf_string(
     Returns
     -------
         The converted value, which could be a boolean, a datetime string,
-        a list of datetime strings, or the original string if no other conditions
-        are met.
+        a list of datetime strings, a timedelta objects, or the original string
+        if no other conditions are met.
     """
     ras_datetime_format1_re = r"\d{2}\w{3}\d{4} \d{2}:\d{2}:\d{2}"
     ras_datetime_format2_re = r"\d{2}\w{3}\d{4} \d{2}\d{2}"

--- a/src/rashdf/utils.py
+++ b/src/rashdf/utils.py
@@ -73,14 +73,18 @@ def parse_duration(duration_str: str) -> timedelta:
     return duration
 
 
-def convert_ras_hdf_string(value: str) -> Union[bool, str, List[str]]:
+def convert_ras_hdf_string(
+    value: str,
+) -> Union[bool, datetime, List[datetime], timedelta, str]:
     """Convert a string value from an HEC-RAS HDF file into a Python object.
 
     This function handles several specific string formats:
-    - "True" and "False" are converted to boolean values.
-    - Strings matching the format "ddMMMyyyy HH:mm:ss" or "ddMMMyyyy HHmm" are parsed into datetime objects.
-    - Strings matching the format "ddMMMyyyy HH:mm:ss to ddMMMyyyy HH:mm:ss" or "ddMMMyyyy HHmm to ddMMMyyyy HHmm"
-    are parsed into a list of two datetime objects.
+    - The strings "True" and "False" are converted to boolean values.
+    - Strings matching the format "ddMMMyyyy HH:mm:ss" or "ddMMMyyyy HHmm"
+      are parsed into datetime objects.
+    - Strings matching the format "ddMMMyyyy HH:mm:ss to ddMMMyyyy HH:mm:ss" or
+      "ddMMMyyyy HHmm to ddMMMyyyy HHmm" are parsed into a list of two datetime objects.
+    - Strings matching the format "HH:mm:ss" are parsed into timedelta objects.
 
     Parameters
     ----------
@@ -88,11 +92,13 @@ def convert_ras_hdf_string(value: str) -> Union[bool, str, List[str]]:
 
     Returns
     -------
-        The converted value, which could be a boolean, a datetime string, a list of datetime strings, or the original
-        string if no other conditions are met.
+        The converted value, which could be a boolean, a datetime string,
+        a list of datetime strings, or the original string if no other conditions
+        are met.
     """
     ras_datetime_format1_re = r"\d{2}\w{3}\d{4} \d{2}:\d{2}:\d{2}"
     ras_datetime_format2_re = r"\d{2}\w{3}\d{4} \d{2}\d{2}"
+    ras_duration_format_re = r"\d{2}:\d{2}:\d{2}"
     s = value.decode("utf-8")
     if s == "True":
         return True
@@ -114,6 +120,8 @@ def convert_ras_hdf_string(value: str) -> Union[bool, str, List[str]]:
                 parse_ras_simulation_window_datetime(split[1]),
             ]
         return parse_ras_simulation_window_datetime(s)
+    elif re.match(rf"^{ras_duration_format_re}$", s):
+        return parse_duration(s)
     return s
 
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -3,7 +3,7 @@ from src.rashdf import utils
 import numpy as np
 import pytest
 
-from datetime import datetime
+from datetime import datetime, timedelta
 
 
 def test_convert_ras_hdf_value():
@@ -18,3 +18,6 @@ def test_convert_ras_hdf_value():
         datetime(2024, 3, 15, 16, 39, 1),
         datetime(2024, 3, 16, 16, 39, 1),
     ]
+    assert utils.convert_ras_hdf_value(b"01:23:45") == timedelta(
+        hours=1, minutes=23, seconds=45
+    )


### PR DESCRIPTION
Ensures that HDF string attributes representing time durations in the format `00:00:00` are converted to `datetime.timedelta` objects.