### PR TITLE
WIP: CLI

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,14 +12,17 @@ classifiers = [
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
 ]
-version = "0.1.1"
-dependencies = ["h5py", "geopandas"]
+version = "0.2.0"
+dependencies = ["h5py", "geopandas", "pyarrow"]
 
 [project.optional-dependencies]
 dev = ["pre-commit", "ruff", "pytest"]
 
 [project.urls]
 repository = "https://github.com/fema-ffrd/rashdf"
+
+[project.scripts]
+rashdf = "cli:main"
 
 [tool.pytest.ini_options]
 pythonpath = "src"

--- a/src/cli.py
+++ b/src/cli.py
@@ -1,0 +1,127 @@
+from rashdf import RasGeomHdf
+
+import fiona
+from geopandas import GeoDataFrame
+
+import argparse
+from ast import literal_eval
+import sys
+from typing import List
+
+
+COMMANDS = [
+    "mesh_areas",
+    "mesh_cell_points",
+    "mesh_cell_polygons",
+    "mesh_cell_faces",
+    "refinement_regions",
+    "bc_lines",
+    "breaklines",
+    "structures",
+]
+
+
+def docstring_to_help(docstring: str) -> str:
+    """Extract the first line of a docstring to use as help text for the rashdf CLI.
+
+    Note that this function replaces 'Return' with 'Export' in the help text.
+
+    Parameters
+    ----------
+    docstring : str
+        The docstring to extract the first line from.
+
+    Returns
+    -------
+    str
+        The first line of the docstring with 'Return' replaced by 'Export'.
+    """
+    help_text = docstring.split("\n")[0]
+    help_text = help_text.replace("Return", "Export")
+    return help_text
+
+
+def fiona_supported_drivers() -> List[str]:
+    """Return a list of drivers supported by Fiona for writing output files.
+
+    Returns
+    -------
+    list
+        A list of drivers supported by Fiona for writing output files.
+    """
+    drivers = [d for d, s in fiona.supported_drivers.items() if "w" in s]
+    return drivers
+
+
+def parse_args(args: str) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Extract data from HEC-RAS HDF files.")
+    parser.add_argument(
+        "--fiona-drivers",
+        action="store_true",
+        help="List the drivers supported by Fiona for writing output files.",
+    )
+    subparsers = parser.add_subparsers(help="Sub-command help")
+    for command in COMMANDS:
+        f = getattr(RasGeomHdf, command)
+        subparser = subparsers.add_parser(
+            command, description=docstring_to_help(f.__doc__)
+        )
+        subparser.set_defaults(func=command)
+        subparser.add_argument("hdf_file", type=str, help="Path to HEC-RAS HDF file.")
+        subparser.add_argument("output_file", type=str, help="Path to output file.")
+        subparser.add_argument("--to-crs", type=str, help="Output CRS.")
+        output_group = subparser.add_mutually_exclusive_group()
+        output_group.add_argument(
+            "--parquet", action="store_true", help="Output as Parquet."
+        )
+        output_group.add_argument(
+            "--feather", action="store_true", help="Output as Feather."
+        )
+        output_group.add_argument(
+            "--json", action="store_true", help="Output as GeoJSON."
+        )
+        subparser.add_argument(
+            "--kwargs",
+            type=str,
+            help=(
+                "Keyword arguments as a Python dictionary literal"
+                " passed to the corresponding GeoPandas output method."
+            ),
+        )
+    args = parser.parse_args(args)
+    return args
+
+
+def export(args: argparse.Namespace):
+    if args.fiona_drivers:
+        for driver in fiona_supported_drivers():
+            print(driver)
+        return
+    if "://" in args.hdf_file:
+        geom_hdf = RasGeomHdf.open_uri(args.hdf_file)
+    else:
+        geom_hdf = RasGeomHdf(args.hdf_file)
+    func = getattr(geom_hdf, args.func)
+    gdf: GeoDataFrame = func()
+    kwargs = literal_eval(args.kwargs) if args.kwargs else {}
+    if args.to_crs:
+        gdf = gdf.to_crs(args.to_crs)
+    if args.json:
+        gdf.to_json(args.output_file, **kwargs)
+        return
+    elif args.parquet:
+        gdf.to_parquet(args.output_file, **kwargs)
+        return
+    elif args.feather:
+        gdf.to_feather(args.output_file, **kwargs)
+        return
+    gdf.to_file(args.output_file, **kwargs)
+
+
+def main():
+    args = parse_args(sys.argv[1:])
+    export(args)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/rashdf/geom.py
+++ b/src/rashdf/geom.py
@@ -85,7 +85,7 @@ class RasGeomHdf(RasHdf):
         )
 
     def mesh_cell_polygons(self) -> GeoDataFrame:
-        """Return the 2D flow mesh cell polygons.
+        """Return 2D flow mesh cell polygons.
 
         Returns
         -------
@@ -139,7 +139,7 @@ class RasGeomHdf(RasHdf):
         return GeoDataFrame(cell_dict, geometry="geometry", crs=self.projection())
 
     def mesh_cell_points(self) -> GeoDataFrame:
-        """Return the 2D flow mesh cell points.
+        """Return 2D flow mesh cell points.
 
         Returns
         -------
@@ -165,7 +165,7 @@ class RasGeomHdf(RasHdf):
         return GeoDataFrame(pnt_dict, geometry="geometry", crs=self.projection())
 
     def mesh_cell_faces(self) -> GeoDataFrame:
-        """Return the 2D flow mesh cell faces.
+        """Return 2D flow mesh cell faces.
 
         Returns
         -------
@@ -245,7 +245,7 @@ class RasGeomHdf(RasHdf):
         return d2_flow_area_attrs
 
     def bc_lines(self) -> GeoDataFrame:
-        """Return the 2D mesh area boundary condition lines.
+        """Return 2D mesh area boundary condition lines.
 
         Returns
         -------
@@ -294,7 +294,7 @@ class RasGeomHdf(RasHdf):
         )
 
     def breaklines(self) -> GeoDataFrame:
-        """Return the 2D mesh area breaklines.
+        """Return 2D mesh area breaklines.
 
         Returns
         -------
@@ -336,7 +336,7 @@ class RasGeomHdf(RasHdf):
         )
 
     def refinement_regions(self) -> GeoDataFrame:
-        """Return the 2D mesh area refinement regions.
+        """Return 2D mesh area refinement regions.
 
         Returns
         -------
@@ -370,7 +370,7 @@ class RasGeomHdf(RasHdf):
         )
 
     def structures(self) -> GeoDataFrame:
-        """Return the model structures.
+        """Return model structures.
 
         Returns
         -------

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,87 @@
+from src.cli import parse_args, export, docstring_to_help, fiona_supported_drivers
+
+import geopandas as gpd
+from pyproj import CRS
+
+from pathlib import Path
+
+TEST_DATA = Path("./tests/data")
+MUNCIE_G05 = TEST_DATA / "ras/Muncie.g05.hdf"
+
+
+def test_docstring_to_help():
+    docstring = """This is a test docstring.
+    This is not part of the help message.
+    """
+    assert docstring_to_help(docstring) == "This is a test docstring."
+
+    docstring = """Return the something or other.
+    Blah blah blah."""
+    assert docstring_to_help(docstring) == "Export the something or other."
+
+
+def test_fiona_supported_drivers():
+    drivers = fiona_supported_drivers()
+    assert "ESRI Shapefile" in drivers
+    assert "GeoJSON" in drivers
+    assert "GPKG" in drivers
+
+
+def test_parse_args():
+    args = parse_args(["mesh_areas", "test.hdf", "test.json"])
+    assert args.func == "mesh_areas"
+    assert args.hdf_file == "test.hdf"
+    assert args.output_file == "test.json"
+    assert args.to_crs is None
+    assert not args.parquet
+    assert not args.feather
+    assert not args.json
+    assert args.kwargs is None
+
+    args = parse_args(
+        [
+            "mesh_areas",
+            "test.hdf",
+            "test.json",
+            "--to-crs",
+            "EPSG:4326",
+            "--parquet",
+            "--kwargs",
+            '{"compression": "gzip"}',
+        ]
+    )
+    assert args.func == "mesh_areas"
+    assert args.hdf_file == "test.hdf"
+    assert args.output_file == "test.json"
+    assert args.to_crs == "EPSG:4326"
+    assert args.parquet
+    assert not args.feather
+    assert not args.json
+    assert args.kwargs == '{"compression": "gzip"}'
+
+    args = parse_args(["--fiona-drivers"])
+    assert args.fiona_drivers
+
+
+def test_export(tmp_path: Path):
+    test_json_path = tmp_path / "test.json"
+    args = parse_args(["mesh_areas", str(MUNCIE_G05), str(test_json_path)])
+    export(args)
+    gdf = gpd.read_file(test_json_path)
+    assert len(gdf) == 2
+
+    test_parquet_path = tmp_path / "test.parquet"
+    args = parse_args(
+        [
+            "mesh_cell_points",
+            str(MUNCIE_G05),
+            str(test_parquet_path),
+            "--parquet",
+            "--to-crs",
+            "EPSG:4326",
+        ]
+    )
+    export(args)
+    gdf = gpd.read_parquet(test_parquet_path)
+    assert len(gdf) == 5790
+    assert gdf.crs == CRS.from_epsg(4326)


### PR DESCRIPTION
**DO NOT MERGE until #29 is completed. Change the target branch to `main`.**

Creates a command-line interface for `rashdf`.

# Example usage
## Main Help Menu
```
$ rashdf --help
usage: cli.py [-h] [--fiona-drivers] {mesh_areas,mesh_cell_points,mesh_cell_polygons,mesh_cell_faces,refinement_regions,bc_lines,breaklines,structures} ...

Extract data from HEC-RAS HDF files.

positional arguments:
  {mesh_areas,mesh_cell_points,mesh_cell_polygons,mesh_cell_faces,refinement_regions,bc_lines,breaklines,structures}
                        Sub-command help
    mesh_areas          Export 2D flow area perimeter polygons.
    mesh_cell_points    Export 2D flow mesh cell points.
    mesh_cell_polygons  Export 2D flow mesh cell polygons.
    mesh_cell_faces     Export 2D flow mesh cell faces.
    refinement_regions  Export 2D mesh area refinement regions.
    bc_lines            Export 2D mesh area boundary condition lines.
    breaklines          Export 2D mesh area breaklines.
    structures          Export model structures.

options:
  -h, --help            show this help message and exit
  --fiona-drivers       List the drivers supported by Fiona for writing output files.
```

## Subcommand Help
```
$ rashdf mesh_areas --help
usage: cli.py mesh_areas [-h] [--to-crs TO_CRS] [--parquet | --feather | --json] [--kwargs KWARGS] hdf_file output_file

Export 2D flow area perimeter polygons.

positional arguments:
  hdf_file         Path to HEC-RAS HDF file.
  output_file      Path to output file.

options:
  -h, --help       show this help message and exit
  --to-crs TO_CRS  Output CRS.
  --parquet        Output as Parquet.
  --feather        Output as Feather.
  --json           Output as GeoJSON.
  --kwargs KWARGS  Keyword arguments as a Python dictionary literal passed to the corresponding GeoPandas output method.
```

## Export to ESRI Shapefile
```
$ rashdf mesh_cell_points ./models/BigRiver.g01.hdf ./export-data/bigriver-cell-points.shp
```

## Export from S3 HDF to Parquet with CRS Transform
Note: requires installation of optional dependencies `fsspec` and `s3fs`
```
$ rashdf mesh_cell_polygons s3://my-bucket/Potomac.g04.hdf ./export-data/potomac-cell-polygons.parquet --parquet --to-crs "EPSG:4326"
```