### PR TITLE
Test coverage

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -26,6 +26,7 @@ jobs:
         os: ["ubuntu-latest"]
 
     runs-on: ${{ matrix.os }}
+    environment: ci-env
 
     steps:
     - uses: actions/checkout@v4
@@ -45,6 +46,15 @@ jobs:
         ruff check
         ruff format --check
 
-    - name: Test with pytest
+    - name: Run tests with coverage
       run: |
-        pytest
+        pytest --cov=src --cov-report term-missing
+
+    - name: Run coverage
+      run: |
+        coverage xml
+
+    - name: Upload coverage reports to Codecov
+      uses: codecov/codecov-action@v4.0.1
+      with:
+        token: ${{ secrets.CODECOV_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 [![CI](https://github.com/fema-ffrd/rashdf/actions/workflows/continuous-integration.yml/badge.svg?branch=main)](https://github.com/fema-ffrd/rashdf/actions/workflows/continuous-integration.yml)
 [![Release](https://github.com/fema-ffrd/rashdf/actions/workflows/release.yml/badge.svg)](https://github.com/fema-ffrd/rashdf/actions/workflows/release.yml)
 [![PyPI version](https://badge.fury.io/py/rashdf.svg)](https://badge.fury.io/py/rashdf)
+[![codecov](https://codecov.io/gh/fema-ffrd/rashdf/graph/badge.svg?token=CTIIONEHV1)](https://codecov.io/gh/fema-ffrd/rashdf)
 
 Read data from [HEC-RAS](https://www.hec.usace.army.mil/software/hec-ras/) [HDF](https://github.com/HDFGroup/hdf5) files.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ version = "0.2.1"
 dependencies = ["h5py", "geopandas", "pyarrow"]
 
 [project.optional-dependencies]
-dev = ["pre-commit", "ruff", "pytest"]
+dev = ["pre-commit", "ruff", "pytest", "pytest-cov"]
 
 [project.urls]
 repository = "https://github.com/fema-ffrd/rashdf"


### PR DESCRIPTION
Closes #36
* Adds `pytest-cov` as an optional dependency
* Runs test coverage reports as part of CI process
* Uploads test coverage reports to Codecov 

# Reviewing
* Install updated depenencies: `pip install ".[dev]"`
* Run unit tests with coverage: `pytest --cov rashdf`
* Generate a coverage report: `pytest --cov rashdf --cov-report html` (open the HTML files in the `htmlcov` directory to view test coverage reports)
* Check out coverage report generated for this PR on Codecov (red highlighted sections are lines _not_ covered by unit tests): https://app.codecov.io/github/fema-ffrd/rashdf/pull/41/blob/src/rashdf/utils.py