### PR TITLE
Initial Docs

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,0 +1,28 @@
+# .readthedocs.yaml
+# Read the Docs configuration file
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+
+# Required
+version: 2
+
+# Set the OS, Python version and other tools you might need
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.12"
+
+# Build documentation in the "docs/" directory with Sphinx
+sphinx:
+  configuration: docs/conf.py
+
+# Optionally build your docs in additional formats such as PDF and ePub
+# formats:
+#    - pdf
+#    - epub
+
+# Optional but recommended, declare the Python requirements required
+# to build your documentation
+# See https://docs.readthedocs.io/en/stable/guides/reproducible-builds.html
+python:
+   install:
+   - requirements: docs/requirements.txt

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -1,0 +1,20 @@
+# Minimal makefile for Sphinx documentation
+#
+
+# You can set these variables from the command line, and also
+# from the environment for the first two.
+SPHINXOPTS    ?=
+SPHINXBUILD   ?= sphinx-build
+SOURCEDIR     = source
+BUILDDIR      = build
+
+# Put it first so that "make" without argument is like "make help".
+help:
+	@$(SPHINXBUILD) -M help "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
+
+.PHONY: help Makefile
+
+# Catch-all target: route all unknown targets to Sphinx using the new
+# "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).
+%: Makefile
+	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)

--- a/docs/environment.yml
+++ b/docs/environment.yml
@@ -1,0 +1,9 @@
+name: rashdf-docs
+channels:
+  - conda-forge
+  - defaults
+dependencies:
+  - python=3.9
+  - pip
+  - pip:
+      - -e ../[docs]

--- a/docs/make.bat
+++ b/docs/make.bat
@@ -1,0 +1,35 @@
+@ECHO OFF
+
+pushd %~dp0
+
+REM Command file for Sphinx documentation
+
+if "%SPHINXBUILD%" == "" (
+	set SPHINXBUILD=sphinx-build
+)
+set SOURCEDIR=source
+set BUILDDIR=build
+
+%SPHINXBUILD% >NUL 2>NUL
+if errorlevel 9009 (
+	echo.
+	echo.The 'sphinx-build' command was not found. Make sure you have Sphinx
+	echo.installed, then set the SPHINXBUILD environment variable to point
+	echo.to the full path of the 'sphinx-build' executable. Alternatively you
+	echo.may add the Sphinx directory to PATH.
+	echo.
+	echo.If you don't have Sphinx installed, grab it from
+	echo.https://www.sphinx-doc.org/
+	exit /b 1
+)
+
+if "%1" == "" goto help
+
+%SPHINXBUILD% -M %1 %SOURCEDIR% %BUILDDIR% %SPHINXOPTS% %O%
+goto end
+
+:help
+%SPHINXBUILD% -M help %SOURCEDIR% %BUILDDIR% %SPHINXOPTS% %O%
+
+:end
+popd

--- a/docs/source/RasGeomHdf.rst
+++ b/docs/source/RasGeomHdf.rst
@@ -1,0 +1,18 @@
+RasGeomHdf
+==========
+.. currentmodule:: rashdf
+.. autoclass:: RasGeomHdf
+   :show-inheritance:
+   :members: projection,
+             mesh_area_names,
+             mesh_areas,
+             mesh_cell_polygons,
+             mesh_cell_points,
+             mesh_cell_faces,
+             bc_lines,
+             breaklines,
+             refinement_regions,
+             structures,
+             get_geom_attrs,
+             get_geom_structures_attrs,
+             get_geom_2d_flow_area_attrs

--- a/docs/source/RasHdf.rst
+++ b/docs/source/RasHdf.rst
@@ -1,0 +1,7 @@
+RasHdf
+======
+.. currentmodule:: rashdf
+.. autoclass:: RasHdf
+   :show-inheritance:
+   :special-members: __init__,
+                     open_uri

--- a/docs/source/RasPlanHdf.rst
+++ b/docs/source/RasPlanHdf.rst
@@ -1,0 +1,11 @@
+RasPlanHdf
+==========
+.. currentmodule:: rashdf
+.. autoclass:: RasPlanHdf
+   :show-inheritance:
+   :members: get_plan_info_attrs,
+             get_plan_param_attrs,
+             get_meteorology_precip_attrs,
+             get_results_unsteady_attrs,
+             get_results_unsteady_summary_attrs,
+             get_results_volume_accounting_attrs

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -5,7 +5,7 @@
 
 import sys
 
-sys.path.insert(0, "../../src")
+sys.path.insert(0, "src")
 
 # -- Project information -----------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#project-information
@@ -21,6 +21,7 @@ release = "0.2.1"
 extensions = [
     "sphinx.ext.autodoc",
     "sphinx.ext.autosummary",
+    "sphinx_rtd_theme",
     "numpydoc",
 ]
 
@@ -31,5 +32,6 @@ exclude_patterns = []
 # -- Options for HTML output -------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#options-for-html-output
 
-html_theme = "alabaster"
+# html_theme = "alabaster"
+html_theme = "sphinx_rtd_theme"
 html_static_path = ["_static"]

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -1,0 +1,35 @@
+# Configuration file for the Sphinx documentation builder.
+#
+# For the full list of built-in configuration values, see the documentation:
+# https://www.sphinx-doc.org/en/master/usage/configuration.html
+
+import sys
+
+sys.path.insert(0, "../../src")
+
+# -- Project information -----------------------------------------------------
+# https://www.sphinx-doc.org/en/master/usage/configuration.html#project-information
+
+project = "rashdf"
+copyright = "2024, fema-ffrd"
+author = "fema-ffrd"
+release = "0.2.1"
+
+# -- General configuration ---------------------------------------------------
+# https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration
+
+extensions = [
+    "sphinx.ext.autodoc",
+    "sphinx.ext.autosummary",
+    "numpydoc",
+]
+
+templates_path = ["_templates"]
+exclude_patterns = []
+
+
+# -- Options for HTML output -------------------------------------------------
+# https://www.sphinx-doc.org/en/master/usage/configuration.html#options-for-html-output
+
+html_theme = "alabaster"
+html_static_path = ["_static"]

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -95,7 +95,7 @@ API
 
 :code:`rashdf` provides two primary classes for reading data from
 HEC-RAS geometry and plan HDF files: :code:`RasGeomHdf` and :code:`RasPlanHdf`.
-Both of these classes inherit from the `RasHdf` base class, which
+Both of these classes inherit from the :code:`RasHdf` base class, which
 inherits from the :code:`h5py.File` class.
 
 Note that :code:`RasPlanHdf` inherits from :code:`RasGeomHdf`, so all of the

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -1,0 +1,102 @@
+.. rashdf documentation master file, created by
+   sphinx-quickstart on Mon Jun  3 15:55:12 2024.
+   You can adapt this file completely to your liking, but it should at least
+   contain the root `toctree` directive.
+
+
+rashdf Documentation
+====================
+:code:`rashdf` is a library for reading data from `HEC-RAS <https://www.hec.usace.army.mil/software/hec-ras/>`_
+HDF5 files. It is a wrapper around the :code:`h5py` library, and provides an interface with 
+convenience functions for reading key HEC-RAS geometry data, output data,
+and metadata.
+
+Installation
+============
+With :code:`pip`::
+
+   pip install rashdf
+
+
+Quickstart
+==========
+Reading geometry from a HEC-RAS geometry HDF file::
+
+   >>> from rashdf import RasGeomHdf
+   >>> with RasGeomHdf('Muncie.g05.hdf') as geom_hdf:
+   ...     projection = geom_hdf.projection()
+   ...     mesh_area_names = geom_hdf.mesh_area_names()
+   ...     mesh_areas = geom_hdf.mesh_areas()
+   ...     mesh_cell_points = geom_hdf.mesh_cell_points()
+   >>> projection
+   <Projected CRS: EPSG:2965>
+   Name: NAD83 / Indiana East (ftUS)
+   Axis Info [cartesian]:
+   - E[east]: Easting (US survey foot)
+   - N[north]: Northing (US survey foot)
+   Area of Use:
+   - undefined
+   Coordinate Operation:
+   - name: unnamed
+   - method: Transverse Mercator
+   Datum: North American Datum 1983
+   - Ellipsoid: GRS 1980
+   - Prime Meridian: Greenwich
+   >>> mesh_area_names
+   ['2D Interior Area', 'Perimeter_NW']
+   >>> mesh_areas
+             mesh_name                                           geometry
+   0  2D Interior Area  POLYGON ((409537.180 1802597.310, 409426.140 1...
+   1      Perimeter_NW  POLYGON ((403914.470 1804971.220, 403008.310 1...
+   >>> mesh_cell_points
+                mesh_name  cell_id                        geometry
+   0     2D Interior Area        0  POINT (406000.000 1805000.000)
+   1     2D Interior Area        1  POINT (406050.000 1805000.000)
+   2     2D Interior Area        2  POINT (406100.000 1805000.000)
+   3     2D Interior Area        3  POINT (406150.000 1805000.000)
+   4     2D Interior Area        4  POINT (406200.000 1805000.000)
+   ...                ...      ...                             ...
+   5785      Perimeter_NW      514  POINT (403731.575 1804124.860)
+   5786      Perimeter_NW      515  POINT (403650.619 1804121.731)
+   5787      Perimeter_NW      516  POINT (403585.667 1804141.139)
+   5788      Perimeter_NW      517  POINT (403534.818 1804186.902)
+   5789      Perimeter_NW      518  POINT (403632.837 1804235.708)
+
+Reading plan data from a HEC-RAS plan HDF file hosted on AWS S3
+(note, this requires installation of the optional :code:`fsspec`
+and :code:`s3fs` libraries as well as configuration of S3
+credentials)::
+
+   >>> from rashdf import RasPlanHdf
+   >>> with RasPlanHdf.open_uri('s3://bucket/ElkMiddle.p01.hdf') as plan_hdf:
+   ...     plan_info = plan_hdf.get_plan_info_attrs()
+   >>> plan_info
+   {'Base Output Interval': '1HOUR', 'Computation Time Step Base': '1MIN',
+   'Flow Filename': 'ElkMiddle.u01', 'Flow Title': 'Jan_1996',
+   'Geometry Filename': 'ElkMiddle.g01', 'Geometry Title': 'ElkMiddle',
+   'Plan Filename': 'ElkMiddle.p01', 'Plan Name': 'Jan_1996',
+   'Plan ShortID': 'Jan_1996', 'Plan Title': 'Jan_1996',
+   'Project Filename': 'g:\\Jan1996_Kanawha_CloudPrep\\Elk Middle\\ElkMiddle.prj',
+   'Project Title': 'ElkMiddle',
+   'Simulation End Time': datetime.datetime(1996, 2, 7, 12, 0),
+   'Simulation Start Time': datetime.datetime(1996, 1, 14, 12, 0),
+   'Time Window': [datetime.datetime(1996, 1, 14, 12, 0),
+   datetime.datetime(1996, 2, 7, 12, 0)]}
+
+
+API
+===
+.. toctree::
+   :maxdepth: 1
+
+   RasGeomHdf
+   RasPlanHdf
+   RasHdf
+
+:code:`rashdf` provides two primary classes for reading data from
+HEC-RAS geometry and plan HDF files: :code:`RasGeomHdf` and :code:`RasPlanHdf`.
+Both of these classes inherit from the `RasHdf` base class, which
+inherits from the :code:`h5py.File` class.
+
+Note that :code:`RasPlanHdf` inherits from :code:`RasGeomHdf`, so all of the
+methods available in :code:`RasGeomHdf` are also available in :code:`RasPlanHdf`.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ version = "0.2.1"
 dependencies = ["h5py", "geopandas", "pyarrow"]
 
 [project.optional-dependencies]
-dev = ["pre-commit", "ruff", "pytest", "sphinx", "numpydoc"]
+dev = ["pre-commit", "ruff", "pytest", "sphinx", "numpydoc", "sphinx_rtd_theme"]
 
 [project.urls]
 repository = "https://github.com/fema-ffrd/rashdf"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ version = "0.2.1"
 dependencies = ["h5py", "geopandas", "pyarrow"]
 
 [project.optional-dependencies]
-dev = ["pre-commit", "ruff", "pytest"]
+dev = ["pre-commit", "ruff", "pytest", "sphinx", "numpydoc"]
 
 [project.urls]
 repository = "https://github.com/fema-ffrd/rashdf"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,8 @@ version = "0.2.1"
 dependencies = ["h5py", "geopandas", "pyarrow"]
 
 [project.optional-dependencies]
-dev = ["pre-commit", "ruff", "pytest", "sphinx", "numpydoc", "sphinx_rtd_theme"]
+dev = ["pre-commit", "ruff", "pytest"]
+doc = ["sphinx", "numpydoc", "sphinx_rtd_theme"]
 
 [project.urls]
 repository = "https://github.com/fema-ffrd/rashdf"
@@ -28,10 +29,12 @@ rashdf = "cli:main"
 pythonpath = "src"
 testpaths = "tests"
 
-# TODO: linting for docstrings.
-# https://github.com/fema-ffrd/rashdf/issues/15
-# [tool.ruff.lint]
-# select = ["D"]
+[tool.ruff.lint]
+select = ["D"]
 
-# [tool.ruff.lint.pydocstyle]
-# convention = "numpy"
+[tool.ruff.lint.pydocstyle]
+convention = "numpy"
+
+[tool.ruff.lint.per-file-ignores]
+"tests/**" = ["D"]
+"docs/**" = ["D"]

--- a/src/cli.py
+++ b/src/cli.py
@@ -1,3 +1,5 @@
+"""rashdf CLI."""
+
 from rashdf import RasGeomHdf
 from rashdf.utils import df_datetimes_to_str
 
@@ -60,6 +62,7 @@ def fiona_supported_drivers() -> List[str]:
 
 
 def parse_args(args: str) -> argparse.Namespace:
+    """Parse command-line arguments."""
     parser = argparse.ArgumentParser(description="Extract data from HEC-RAS HDF files.")
     parser.add_argument(
         "--fiona-drivers",
@@ -100,6 +103,7 @@ def parse_args(args: str) -> argparse.Namespace:
 
 
 def export(args: argparse.Namespace) -> Optional[str]:
+    """Act on parsed arguments to extract data from HEC-RAS HDF files."""
     if args.fiona_drivers:
         for driver in fiona_supported_drivers():
             print(driver)
@@ -147,6 +151,7 @@ def export(args: argparse.Namespace) -> Optional[str]:
 
 
 def main():
+    """Entry point for the rashdf CLI."""
     args = parse_args(sys.argv[1:])
     export(args)
 

--- a/src/rashdf/__init__.py
+++ b/src/rashdf/__init__.py
@@ -1,3 +1,5 @@
+"""rashdf package."""
+
 from .base import RasHdf
 from .geom import RasGeomHdf
 from .plan import RasPlanHdf

--- a/src/rashdf/base.py
+++ b/src/rashdf/base.py
@@ -1,3 +1,5 @@
+"""Base class for reading HEC-RAS HDF files."""
+
 import h5py
 from .utils import hdf5_attrs_to_dict
 from typing import Dict
@@ -68,7 +70,7 @@ class RasHdf(h5py.File):
         return {}
 
     def get_root_attrs(self):
-        """Returns attributes at root level of HEC-RAS HDF file.
+        """Return attributes at root level of HEC-RAS HDF file.
 
         Returns
         -------

--- a/src/rashdf/geom.py
+++ b/src/rashdf/geom.py
@@ -1,3 +1,5 @@
+"""HEC-RAS Geometry HDF class."""
+
 from .base import RasHdf
 from .utils import (
     convert_ras_hdf_string,
@@ -42,8 +44,7 @@ class RasGeomHdf(RasHdf):
         super().__init__(name, **kwargs)
 
     def projection(self) -> Optional[CRS]:
-        """Return the projection of the RAS geometry as a
-        pyproj.CRS object.
+        """Return the projection of the RAS geometry as a pyproj.CRS object.
 
         Returns
         -------
@@ -58,8 +59,7 @@ class RasGeomHdf(RasHdf):
         return CRS.from_wkt(proj_wkt)
 
     def mesh_area_names(self) -> List[str]:
-        """Return a list of the 2D mesh area names of
-        the RAS geometry.
+        """Return a list of the 2D mesh area names of the RAS geometry.
 
         Returns
         -------
@@ -218,7 +218,7 @@ class RasGeomHdf(RasHdf):
         return GeoDataFrame(face_dict, geometry="geometry", crs=self.projection())
 
     def get_geom_attrs(self) -> Dict:
-        """Returns base geometry attributes from a HEC-RAS HDF file.
+        """Return base geometry attributes from a HEC-RAS HDF file.
 
         Returns
         -------
@@ -228,7 +228,7 @@ class RasGeomHdf(RasHdf):
         return self.get_attrs(self.GEOM_PATH)
 
     def get_geom_structures_attrs(self) -> Dict:
-        """Returns geometry structures attributes from a HEC-RAS HDF file.
+        """Return geometry structures attributes from a HEC-RAS HDF file.
 
         Returns
         -------
@@ -238,7 +238,7 @@ class RasGeomHdf(RasHdf):
         return self.get_attrs(self.GEOM_STRUCTURES_PATH)
 
     def get_geom_2d_flow_area_attrs(self) -> Dict:
-        """Returns geometry 2d flow area attributes from a HEC-RAS HDF file.
+        """Return geometry 2d flow area attributes from a HEC-RAS HDF file.
 
         Returns
         -------
@@ -435,50 +435,50 @@ class RasGeomHdf(RasHdf):
             )
         return struct_gdf
 
-    def connections(self) -> GeoDataFrame:
+    def connections(self) -> GeoDataFrame:  # noqa D102
         raise NotImplementedError
 
-    def ic_points(self) -> GeoDataFrame:
+    def ic_points(self) -> GeoDataFrame:  # noqa D102
         raise NotImplementedError
 
-    def reference_lines(self) -> GeoDataFrame:
+    def reference_lines(self) -> GeoDataFrame:  # noqa D102
         raise NotImplementedError
 
-    def reference_points(self) -> GeoDataFrame:
+    def reference_points(self) -> GeoDataFrame:  # noqa D102
         raise NotImplementedError
 
-    def pump_stations(self) -> GeoDataFrame:
+    def pump_stations(self) -> GeoDataFrame:  # noqa D102
         raise NotImplementedError
 
-    def mannings_calibration_regions(self) -> GeoDataFrame:
+    def mannings_calibration_regions(self) -> GeoDataFrame:  # noqa D102
         raise NotImplementedError
 
-    def classification_polygons(self) -> GeoDataFrame:
+    def classification_polygons(self) -> GeoDataFrame:  # noqa D102
         raise NotImplementedError
 
-    def terrain_modifications(self) -> GeoDataFrame:
+    def terrain_modifications(self) -> GeoDataFrame:  # noqa D102
         raise NotImplementedError
 
-    def cross_sections(self) -> GeoDataFrame:
+    def cross_sections(self) -> GeoDataFrame:  # noqa D102
         raise NotImplementedError
 
-    def river_reaches(self) -> GeoDataFrame:
+    def river_reaches(self) -> GeoDataFrame:  # noqa D102
         raise NotImplementedError
 
-    def flowpaths(self) -> GeoDataFrame:
+    def flowpaths(self) -> GeoDataFrame:  # noqa D102
         raise NotImplementedError
 
-    def bank_points(self) -> GeoDataFrame:
+    def bank_points(self) -> GeoDataFrame:  # noqa D102
         raise NotImplementedError
 
-    def bank_lines(self) -> GeoDataFrame:
+    def bank_lines(self) -> GeoDataFrame:  # noqa D102
         raise NotImplementedError
 
-    def ineffective_areas(self) -> GeoDataFrame:
+    def ineffective_areas(self) -> GeoDataFrame:  # noqa D102
         raise NotImplementedError
 
-    def ineffective_points(self) -> GeoDataFrame:
+    def ineffective_points(self) -> GeoDataFrame:  # noqa D102
         raise NotImplementedError
 
-    def blocked_obstructions(self) -> GeoDataFrame:
+    def blocked_obstructions(self) -> GeoDataFrame:  # noqa D102
         raise NotImplementedError

--- a/src/rashdf/geom.py
+++ b/src/rashdf/geom.py
@@ -47,7 +47,7 @@ class RasGeomHdf(RasHdf):
 
         Returns
         -------
-        CRS
+        pyproj.CRS or None
             The projection of the RAS geometry.
         """
         proj_wkt = self.attrs.get("Projection")
@@ -63,7 +63,7 @@ class RasGeomHdf(RasHdf):
 
         Returns
         -------
-        list
+        List[str]
             A list of the 2D mesh area names (str) within the RAS geometry if 2D areas exist.
         """
         if "/Geometry/2D Flow Areas" not in self:

--- a/src/rashdf/geom.py
+++ b/src/rashdf/geom.py
@@ -19,15 +19,26 @@ from shapely import (
     polygonize,
 )
 
-from typing import List, Optional
+from typing import Dict, List, Optional
 
 
 class RasGeomHdf(RasHdf):
+    """HEC-RAS Geometry HDF class."""
+
     GEOM_PATH = "Geometry"
     GEOM_STRUCTURES_PATH = f"{GEOM_PATH}/Structures"
     FLOW_AREA_2D_PATH = f"{GEOM_PATH}/2D Flow Areas"
 
     def __init__(self, name: str, **kwargs):
+        """Open a HEC-RAS Geometry HDF file.
+
+        Parameters
+        ----------
+        name : str
+            The path to the RAS Geometry HDF file.
+        kwargs : dict
+            Additional keyword arguments to pass to h5py.File
+        """
         super().__init__(name, **kwargs)
 
     def projection(self) -> Optional[CRS]:
@@ -206,7 +217,7 @@ class RasGeomHdf(RasHdf):
                 face_dict["geometry"].append(LineString(coordinates))
         return GeoDataFrame(face_dict, geometry="geometry", crs=self.projection())
 
-    def get_geom_attrs(self):
+    def get_geom_attrs(self) -> Dict:
         """Returns base geometry attributes from a HEC-RAS HDF file.
 
         Returns
@@ -216,7 +227,7 @@ class RasGeomHdf(RasHdf):
         """
         return self.get_attrs(self.GEOM_PATH)
 
-    def get_geom_structures_attrs(self):
+    def get_geom_structures_attrs(self) -> Dict:
         """Returns geometry structures attributes from a HEC-RAS HDF file.
 
         Returns
@@ -226,7 +237,7 @@ class RasGeomHdf(RasHdf):
         """
         return self.get_attrs(self.GEOM_STRUCTURES_PATH)
 
-    def get_geom_2d_flow_area_attrs(self):
+    def get_geom_2d_flow_area_attrs(self) -> Dict:
         """Returns geometry 2d flow area attributes from a HEC-RAS HDF file.
 
         Returns
@@ -372,6 +383,11 @@ class RasGeomHdf(RasHdf):
 
     def structures(self, datetime_to_str: bool = False) -> GeoDataFrame:
         """Return the model structures.
+
+        Parameters
+        ----------
+        datetime_to_str : bool, optional
+            If True, convert datetime values to string format (default: False).
 
         Returns
         -------

--- a/src/rashdf/plan.py
+++ b/src/rashdf/plan.py
@@ -1,3 +1,5 @@
+"""HEC-RAS Plan HDF class."""
+
 from .geom import RasGeomHdf
 from typing import Dict
 from geopandas import GeoDataFrame
@@ -26,64 +28,64 @@ class RasPlanHdf(RasGeomHdf):
         super().__init__(name, **kwargs)
 
     def get_plan_info_attrs(self) -> Dict:
-        """Returns plan information attributes from a HEC-RAS HDF plan file.
+        """Return plan information attributes from a HEC-RAS HDF plan file.
 
         Returns
         -------
         dict
-            Dictionary filled with plan information attributes.
+            Dictionary of plan information attributes.
         """
         return self.get_attrs(self.PLAN_INFO_PATH)
 
     def get_plan_param_attrs(self) -> Dict:
-        """Returns plan parameter attributes from a HEC-RAS HDF plan file.
+        """Return plan parameter attributes from a HEC-RAS HDF plan file.
 
         Returns
         -------
         dict
-            Dictionary filled with plan parameter attributes.
+            Dictionary of plan parameter attributes.
         """
         return self.get_attrs(self.PLAN_PARAMS_PATH)
 
     def get_meteorology_precip_attrs(self) -> Dict:
-        """Returns precipitation attributes from a HEC-RAS HDF plan file.
+        """Return precipitation attributes from a HEC-RAS HDF plan file.
 
         Returns
         -------
         dict
-            Dictionary filled with precipitation attributes.
+            Dictionary of precipitation attributes.
         """
         return self.get_attrs(self.PRECIP_PATH)
 
     def get_results_unsteady_attrs(self) -> Dict:
-        """Returns unsteady attributes from a HEC-RAS HDF plan file.
+        """Return unsteady attributes from a HEC-RAS HDF plan file.
 
         Returns
         -------
         dict
-            Dictionary filled with unsteady attributes.
+            Dictionary of unsteady attributes.
         """
         return self.get_attrs(self.RESULTS_UNSTEADY_PATH)
 
     def get_results_unsteady_summary_attrs(self) -> Dict:
-        """Returns results unsteady summary attributes from a HEC-RAS HDF plan file.
+        """Return results unsteady summary attributes from a HEC-RAS HDF plan file.
 
         Returns
         -------
         dict
-            Dictionary filled with results summary attributes.
+            Dictionary of results summary attributes.
         """
         return self.get_attrs(self.RESULTS_UNSTEADY_SUMMARY_PATH)
 
     def get_results_volume_accounting_attrs(self) -> Dict:
-        """Returns volume accounting attributes from a HEC-RAS HDF plan file.
+        """Return volume accounting attributes from a HEC-RAS HDF plan file.
 
         Returns
         -------
         dict
-            Dictionary filled with volume accounting attributes.
+            Dictionary of volume accounting attributes.
         """
         return self.get_attrs(self.VOLUME_ACCOUNTING_PATH)
 
-    def enroachment_points(self) -> GeoDataFrame:
+    def enroachment_points(self) -> GeoDataFrame:  # noqa: D102
         raise NotImplementedError

--- a/src/rashdf/plan.py
+++ b/src/rashdf/plan.py
@@ -4,6 +4,8 @@ from geopandas import GeoDataFrame
 
 
 class RasPlanHdf(RasGeomHdf):
+    """HEC-RAS Plan HDF class."""
+
     PLAN_INFO_PATH = "Plan Data/Plan Information"
     PLAN_PARAMS_PATH = "Plan Data/Plan Parameters"
     PRECIP_PATH = "Event Conditions/Meteorology/Precipitation"
@@ -12,6 +14,15 @@ class RasPlanHdf(RasGeomHdf):
     VOLUME_ACCOUNTING_PATH = f"{RESULTS_UNSTEADY_PATH}/Volume Accounting"
 
     def __init__(self, name: str, **kwargs):
+        """Open a HEC-RAS Plan HDF file.
+
+        Parameters
+        ----------
+        name : str
+            The path to the RAS Plan HDF file.
+        kwargs : dict
+            Additional keyword arguments to pass to h5py.File
+        """
         super().__init__(name, **kwargs)
 
     def get_plan_info_attrs(self) -> Dict:

--- a/src/rashdf/utils.py
+++ b/src/rashdf/utils.py
@@ -1,3 +1,5 @@
+"""Utility functions for reading HEC-RAS HDF data."""
+
 import h5py
 import numpy as np
 import pandas as pd
@@ -8,9 +10,9 @@ from typing import Any, List, Tuple, Union, Optional
 
 
 def parse_ras_datetime(datetime_str: str) -> datetime:
-    """
-    Parse a datetime string from a RAS file into a datetime object. If the datetime has
-    a time of 2400, then it is converted to midnight of the next day.
+    """Parse a datetime string from a RAS file into a datetime object.
+
+    If the datetime has a time of 2400, then it is converted to midnight of the next day.
 
     Parameters
     ----------
@@ -34,8 +36,9 @@ def parse_ras_datetime(datetime_str: str) -> datetime:
 
 def parse_ras_simulation_window_datetime(datetime_str) -> datetime:
     """
-    Parse a datetime string from a RAS simulation window into a datetime object.If the datetime has a
-    time of 2400, then it is converted to midnight of the next day.
+    Parse a datetime string from a RAS simulation window into a datetime object.
+
+    If the datetime has a time of 2400, then it is converted to midnight of the next day.
 
     Parameters
     ----------
@@ -202,13 +205,13 @@ def hdf5_attrs_to_dict(attrs: dict, prefix: str = None) -> dict:
     """
     Convert a dictionary of attributes from an HDF5 file into a Python dictionary.
 
-    Parameters:
+    Parameters
     ----------
         attrs (dict): The attributes to be converted.
         prefix (str, optional): An optional prefix to prepend to the keys.
 
-    Returns:
-    ----------
+    Returns
+    -------
         dict: A dictionary with the converted attributes.
     """
     results = {}
@@ -229,12 +232,12 @@ def get_first_hdf_group(parent_group: h5py.Group) -> Optional[h5py.Group]:
     This function iterates over the items in the parent group and returns the first item that is an instance of
      h5py.Group. If no such item is found, it returns None.
 
-    Parameters:
+    Parameters
     ----------
         parent_group (h5py.Group): The parent group to search in.
 
-    Returns:
-    ----------
+    Returns
+    -------
         Optional[h5py.Group]: The first HDF5 group in the parent group, or None if no group is found.
     """
     for _, item in parent_group.items():


### PR DESCRIPTION
* Initial documentation setup with Sphinx
* Includes settings to deploy to [readthedocs](https://docs.readthedocs.io/en/stable/index.html#) (should happen automatically after this is merged 🤞)
* Docstring linting with Ruff

# Reviewing
* Install documentation dependencies: `pip install ".[doc]"`
* Generate the documentation: `sphinx-build -M html docs/source docs/build`
* Open the generated HTML docs: `./docs/build/html/index.html`

## Notes
* I tried to set this up so that things are pretty easy to slip into the documentation.
* If you add a new method in `RasPlanHdf` for example, just make sure it has a docstring and then add the method name to `./docs/source/RasPlanHdf.rst` and it should automatically get picked up by Sphinx.
* Personally I'm not super concerned about the actual content of the docs at this point. More concerned about just getting documentation builds working.
* This is new territory for me... chances are high that I've overlooked something.
