### PR TITLE
Fix: conda.environment key for .readthedocs.yml

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -23,6 +23,5 @@ sphinx:
 # Optional but recommended, declare the Python requirements required
 # to build your documentation
 # See https://docs.readthedocs.io/en/stable/guides/reproducible-builds.html
-python:
-   install:
-   - requirements: docs/environment.yml
+conda:
+   environment: docs/environment.yml


### PR DESCRIPTION
Modifies `.readthedocs.yml` to set the `conda.environment` key.