### PR TITLE
change path to sphinx conf.py

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -13,7 +13,7 @@ build:
 
 # Build documentation in the "docs/" directory with Sphinx
 sphinx:
-  configuration: docs/conf.py
+  configuration: docs/source/conf.py
 
 # Optionally build your docs in additional formats such as PDF and ePub
 # formats:


### PR DESCRIPTION
Fixes a build issue with ReadTheDocs where the Sphinx `conf.py` configuration file couldn't be found.

https://readthedocs.org/projects/rashdf/builds/24604364/