### PR TITLE
Upgrade to GeoPandas 1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,9 +72,9 @@ CLI help:
 $ rashdf --help
 ```
 
-Print the output formats supported by Fiona:
+Print the output formats supported by pyorgio:
 ```
-$ rashdf --fiona-drivers
+$ rashdf --pyogrio-drivers
 ```
 
 Help for a specific subcommand:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,10 +13,10 @@ classifiers = [
     "Programming Language :: Python :: 3.12",
 ]
 version = "0.5.0"
-dependencies = ["h5py", "geopandas>=0.14,<0.15", "pyarrow", "xarray"]
+dependencies = ["h5py", "geopandas>=1.0,<2.0", "pyarrow", "xarray"]
 
 [project.optional-dependencies]
-dev = ["pre-commit", "ruff", "pytest", "pytest-cov"]
+dev = ["pre-commit", "ruff", "pytest", "pytest-cov", "fiona"]
 docs = ["sphinx", "numpydoc", "sphinx_rtd_theme"]
 
 [project.urls]

--- a/src/cli.py
+++ b/src/cli.py
@@ -52,12 +52,12 @@ def docstring_to_help(docstring: Optional[str]) -> str:
 
 
 def pyogrio_supported_drivers() -> List[str]:
-    """Return a list of drivers supported by PyOGRIO for writing output files.
+    """Return a list of drivers supported by pyogrio for writing output files.
 
     Returns
     -------
     list
-        A list of drivers supported by PyOGRIO for writing output files.
+        A list of drivers supported by pyogrio for writing output files.
     """
     import pyogrio
 

--- a/tests/test_plan.py
+++ b/tests/test_plan.py
@@ -144,7 +144,7 @@ def test_mesh_cell_points_with_output(tmp_path):
     )
     temp_points = tmp_path / "temp-bald-eagle-mesh-cell-points.geojson"
     gdf = gdf.to_crs(4326)
-    gdf.to_file(temp_points)
+    gdf.to_file(temp_points, engine="fiona")
     valid = get_sha1_hash(TEST_JSON / "bald-eagle-mesh-cell-points.geojson")
     test = get_sha1_hash(temp_points)
     assert valid == test
@@ -161,7 +161,7 @@ def test_mesh_cell_polygons_with_output(tmp_path):
         ],
     )
     temp_polygons = tmp_path / "temp-bald-eagle-mesh-cell-polygons.geojson"
-    gdf.to_crs(4326).to_file(temp_polygons)
+    gdf.to_crs(4326).to_file(temp_polygons, engine="fiona")
     valid = get_sha1_hash(TEST_JSON / "bald-eagle-mesh-cell-polygons.geojson")
     test = get_sha1_hash(temp_polygons)
     assert valid == test
@@ -177,7 +177,7 @@ def test_mesh_cell_faces_with_output(tmp_path):
         ],
     )
     temp_faces = tmp_path / "temp-bald-eagle-mesh-cell-faces.geojson"
-    gdf.to_crs(4326).to_file(temp_faces)
+    gdf.to_crs(4326).to_file(temp_faces, engine="fiona")
     valid = get_sha1_hash(TEST_JSON / "bald-eagle-mesh-cell-faces.geojson")
     test = get_sha1_hash(temp_faces)
     assert valid == test
@@ -271,7 +271,7 @@ def test_reference_lines(tmp_path: Path):
     plan_hdf = RasPlanHdf(BALD_EAGLE_P18_REF)
     gdf = plan_hdf.reference_lines(datetime_to_str=True)
     temp_lines = tmp_path / "temp-bald-eagle-reference-lines.geojson"
-    gdf.to_crs(4326).to_file(temp_lines)
+    gdf.to_crs(4326).to_file(temp_lines, engine="fiona")
     with open(TEST_JSON / "bald-eagle-reflines.geojson") as f:
         valid_lines = f.read()
         with open(temp_lines) as f:
@@ -310,7 +310,7 @@ def test_reference_points(tmp_path: Path):
     plan_hdf = RasPlanHdf(BALD_EAGLE_P18_REF)
     gdf = plan_hdf.reference_points(datetime_to_str=True)
     temp_lines = tmp_path / "temp-bald-eagle-reference-points.geojson"
-    gdf.to_crs(4326).to_file(temp_lines)
+    gdf.to_crs(4326).to_file(temp_lines, engine="fiona")
     with open(TEST_JSON / "bald-eagle-refpoints.geojson") as f:
         valid_points = f.read()
         with open(temp_lines) as f:


### PR DESCRIPTION
⚠ **Merge AFTER #56. Change base to `main`.** ⚠

GeoPandas 1.0.0 and 1.0.1 were released in late June / early July 2024. Most of our code is unaffected, but there was a major dependency change at version 1.0.0 -- GeoPandas now relies on `pyogrio` for file input/output by default instead of Fiona (though Fiona is still supported).
https://geopandas.org/en/stable/docs/changelog.html#version-1-0-0-june-24-2024

* Includes changes to accommodate both `pyogrio` and Fiona for writing RAS data.
* Specifies the Fiona engine for some unit tests due to minor differences between data written by `pyogrio` and Fiona.