### PR TITLE
update release workflow to use PyPI Trusted Publisher auth

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,6 +12,8 @@ jobs:
   release:
     name: release
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
     steps:
       - uses: actions/checkout@v4
       - name: Set up Python
@@ -21,13 +23,9 @@ jobs:
       - name: Install release dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install build twine
+          pip install build
       - name: Build wheel and source distribution
         run: |
           python -m build
       - name: Publish package
-        env:
-          TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}
-          TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
-        run: |
-          twine upload dist/*
+        uses: pypa/gh-action-pypi-publish@release/v1


### PR DESCRIPTION
# Description
* Release pipeline failing because PyPI no longer allows username / password auth.
* Updates release pipeline to use Trusted Publisher authentication.