### PR TITLE
Raise Error for Missing Mesh Areas

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ classifiers = [
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
 ]
-version = "0.8.1"
+version = "0.8.2"
 dependencies = ["h5py", "geopandas>=1.0,<2.0", "pyarrow", "xarray<=2025.4.0"]
 
 [project.optional-dependencies]

--- a/src/rashdf/geom.py
+++ b/src/rashdf/geom.py
@@ -106,10 +106,15 @@ class RasGeomHdf(RasHdf):
         mesh_area_names = self.mesh_area_names()
         if not mesh_area_names:
             return GeoDataFrame()
-        mesh_area_polygons = [
-            Polygon(self[f"{self.FLOW_AREA_2D_PATH}/{n}/Perimeter"][()])
-            for n in mesh_area_names
-        ]
+
+        mesh_area_polygons = []
+        for n in mesh_area_names:
+            try:
+                mesh_area_polygons.append(
+                    Polygon(self[f"{self.FLOW_AREA_2D_PATH}/{n}/Perimeter"][()])
+                )
+            except KeyError as e:
+                raise RasGeomHdfError(f"Data for mesh '{n}' not found.") from e
         return GeoDataFrame(
             {"mesh_name": mesh_area_names, "geometry": mesh_area_polygons},
             geometry="geometry",


### PR DESCRIPTION
`rashdf.mesh_areas()` now catches when a Mesh is missing and throws an error message. 

Closes Issue #79 